### PR TITLE
Log to dcm2bids.log, better directory hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,28 @@ DICOM to NIfTI conversion is done with `dcm2niix` converter. See their [github][
 ## Usage
 
 ```
-dcm2bids [-h] -d DICOM_DIR -p PARTICIPANT [-s SESSION] -c CONFIG
-         [--dry_dcm2niix] [-y]
+usage: dcm2bids [-h] -d DICOM_DIR [DICOM_DIR ...] -p PARTICIPANT -c CONFIG
+                [-s SESSION] [--clobber] [-n SELECTSERIES [SELECTSERIES ...]]
+                [-o OUTPUTDIR]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -d DICOM_DIR [DICOM_DIR ...], --dicom_dir DICOM_DIR [DICOM_DIR ...]
+                        DICOM files directory(ies). Wild cards are supported.
+  -p PARTICIPANT, --participant PARTICIPANT
+                        Participant number in BIDS output
+  -c CONFIG, --config CONFIG
+                        JSON configuration file (see example/config.json)
+  -s SESSION, --session SESSION
+                        Session name/number
+  --clobber             Overwrite output if it exists
+  -n SELECTSERIES [SELECTSERIES ...], --selectseries SELECTSERIES [SELECTSERIES ...]
+                        Select subset of series numbers (integers) for
+                        conversion
+  -o OUTPUTDIR, --outputdir OUTPUTDIR
+                        Output BIDS study directory (default current
+                        directory)
 ```
-
-You need to build the config file of your study to let `dcm2bids` associate your acquisitions with the right dicoms through bids sidecar created by dcm2niix. Every study is different and this step needs a little bit of work.
-
-The configuration uses the `json` format and one example is provided in the `example` directory.
 
 #### Descriptions
 
@@ -35,7 +50,8 @@ The description field is a list of dictionnary. Each dictionnary describes one a
 
 #### Output
 
-dcm2bids create `sub-<PARTICIPANT>` directories in the folder the script is launched.
+dcm2bids creates `sub-<PARTICIPANT>` directories in the output directory (by
+default the folder where the script is launched).
 
 Acquisitions with no or more than one fitting descriptions are kept in `tmp_dcm2niix` directory. Users can review these missing acquistions to change the configuration file accordingly.
 

--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -13,11 +13,13 @@ class Dcm2bids(object):
     """
     """
 
-    def __init__(self, dicom_dir, config, clobber, participant, session=None):
+    def __init__(self, dicom_dir, config, clobber, participant, session=None,
+                 selectseries=None):
         self.dicomDir = dicom_dir
         self.config = load_json(config)
         self.clobber = clobber
         self.participant = Participant(participant, session)
+        self.selectseries = selectseries
 
 
     @property
@@ -32,7 +34,8 @@ class Dcm2bids(object):
     def run(self):
         dcm2niix = Dcm2niix(self.dicomDir, self.participant)
         dcm2niix.run()
-        parser = Sidecarparser(dcm2niix.sidecars, self.config["descriptions"])
+        parser = Sidecarparser(dcm2niix.sidecars,
+                               self.config["descriptions"], self.selectseries)
 
         for acq in parser.acquisitions:
             self._move(acq)

--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -3,10 +3,12 @@
 
 import glob
 import os
+import datetime
+from collections import OrderedDict
 from .dcm2niix import Dcm2niix
 from .sidecarparser import Sidecarparser
 from .structure import Participant
-from .utils import load_json, make_directory_tree, splitext_
+from .utils import load_json, make_directory_tree, splitext_, save_json, write_txt, read_participants, write_participants
 
 
 class Dcm2bids(object):
@@ -14,12 +16,15 @@ class Dcm2bids(object):
     """
 
     def __init__(self, dicom_dir, config, clobber, participant, session=None,
-                 selectseries=None):
+                 selectseries=None, outputdir=os.getcwd()):
         self.dicomDir = dicom_dir
         self.config = load_json(config)
         self.clobber = clobber
         self.participant = Participant(participant, session)
         self.selectseries = selectseries
+        self.outputdir = outputdir
+        if not os.path.exists(self.outputdir):
+            os.makedirs(self.outputdir)
 
 
     @property
@@ -32,20 +37,27 @@ class Dcm2bids(object):
 
 
     def run(self):
+        # convert dicoms to temporary dir
         dcm2niix = Dcm2niix(self.dicomDir, self.participant)
         dcm2niix.run()
+
+        # detect and label acquisitions of interest
         parser = Sidecarparser(dcm2niix.sidecars,
                                self.config["descriptions"], self.selectseries)
 
+        # move identified acquisitions to the BIDS-form outputdir
         for acq in parser.acquisitions:
             self._move(acq)
 
+        # update standard study files, if any acquisitions were found
+        if parser.acquisitions:
+            self._updatestudyfiles()
         return 0
 
 
     def _move(self, acquisition):
         targetDir = os.path.join(
-                os.getcwd(), self.participant.directory, acquisition.dataType)
+                self.outputdir, self.participant.directory, acquisition.dataType)
         filename = "{}_{}".format(self.participant.prefix, acquisition.suffix)
         targetBase = os.path.join(targetDir, filename)
 
@@ -66,3 +78,38 @@ class Dcm2bids(object):
             else:
                 print("'{}' already exists".format(filename))
 
+
+    def _updatestudyfiles(self):
+        # participant table
+        partfile = os.path.join(self.outputdir,"participants.tsv")
+        participants = read_participants(partfile)
+        if not participants or not any([part["participant_id"]==self.participant.name
+                                        for part in participants]):
+            participants.append(
+                OrderedDict(zip(("participant_id","age","sex","group"),
+                                (self.participant.name,"n/a","n/a","n/a"))))
+        write_participants(partfile, participants)
+
+        # dataset description
+        descfile = os.path.join(self.outputdir,'dataset_description.json')
+        if not os.path.exists(descfile):
+            save_json({"Name": "", "BIDSVersion": "1.0.1",
+                        "License": "", "Authors": [""],
+                        "Acknowledgments": "",
+                        "HowToAcknowledge": "",
+                        "Funding": "",
+                        "ReferencesAndLinks": [""],
+                        "DatasetDOI": ""}, descfile)
+
+        # readme/change files
+        readmefile = os.path.join(self.outputdir,'README')
+        if not os.path.exists(readmefile):
+            write_txt(readmefile)
+        changefile = os.path.join(self.outputdir,'CHANGES')
+        if not os.path.exists(changefile):
+            write_txt(changefile,
+                      ["Revision history for BIDS dataset.",
+                       "",
+                       "0.01 " + datetime.date.today().strftime("%Y-%m-%d"),
+                       "",
+                       " - Initialised study directory"])

--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -25,6 +25,7 @@ class Dcm2bids(object):
         self.selectseries = selectseries
         derivdir = os.path.join(outputdir, "derivatives")
         self.outputdir = os.path.join(outputdir,"sourcedata")
+        self.dicomdir = os.path.join(outputdir,'tmp_dcm2bids')
         if not os.path.exists(self.outputdir):
             os.makedirs(self.outputdir)
         if not os.path.exists(derivdir):
@@ -55,7 +56,7 @@ class Dcm2bids(object):
         # convert dicoms to temporary dir
 
         self.logger.info("running dcm2niix DICOM to NIFTI conversion")
-        dcm2niix = Dcm2niix(self.dicom_dir, self.participant)
+        dcm2niix = Dcm2niix(self.dicom_dir, self.participant, outputdir=self.dicomdir)
         dcm2niix.run()
 
         self.logger.info("parsing sidecars")

--- a/dcm2bids/dcm2niix.py
+++ b/dcm2bids/dcm2niix.py
@@ -22,20 +22,23 @@ class Dcm2niix(object):
     """
     """
 
-    def __init__(self, dicom_dir, participant=None, output="dcm2niix-example"):
+    def __init__(self, dicom_dir, participant=None, output="dcm2niix-example",
+                 outputdir=os.path.join(os.getcwd(), 'tmp_dcm2bids')):
         self.dicomDir = dicom_dir
         self.participant = participant
         self.output = output
+        self.outputdir = outputdir
+        if not os.path.exists(self.outputdir):
+            os.makedirs(self.outputdir)
         self.options = "-b y -ba y -z y -f '%f_%p_%t_series%3s'"
         self.sidecars = []
 
     @property
     def outputDir(self):
         if self.participant is None:
-            return os.path.join(os.getcwd(), "tmp_dcm2bids", self.output)
+            return os.path.join(self.outputdir, self.output)
         else:
-            return os.path.join(
-                    os.getcwd(), "tmp_dcm2bids", self.participant.prefix)
+            return os.path.join(self.outputdir, self.participant.prefix)
 
 
     def run(self):

--- a/dcm2bids/structure.py
+++ b/dcm2bids/structure.py
@@ -55,7 +55,7 @@ class Acquisition(object):
     """
     """
 
-    def __init__(self, base, dataType, suffix, customLabels=None):
+    def __init__(self, base, dataType, suffix, customLabels=""):
         self.base = base
         self.dataType = dataType
         self._suffix = suffix
@@ -65,7 +65,7 @@ class Acquisition(object):
     @property
     def suffix(self):
         suffix = ''
-        if self.customLabels is not None:
+        if self.customLabels:
             suffix += '{}_'.format(self.customLabels)
         suffix += self._suffix
         return suffix

--- a/dcm2bids/utils.py
+++ b/dcm2bids/utils.py
@@ -4,13 +4,37 @@
 import json
 import os
 import shutil
-
+import csv
 
 def load_json(filename):
     with open(filename, 'r') as f:
         data = json.load(f)
     return data
 
+
+def save_json(data, filename):
+    with open(filename, 'w') as f:
+        json.dump(data, f)
+
+
+def write_txt(filename,lines=[]):
+    with open(filename, 'a') as f:
+        for row in lines:
+            f.write("%s\n" % row)
+
+def write_participants(filename,participants):
+    with open(filename, 'w') as f:
+        writer = csv.DictWriter(f, delimiter='\t',
+                                fieldnames=participants[0].keys())
+        writer.writeheader()
+        writer.writerows(participants)
+
+def read_participants(filename):
+    if not os.path.exists(filename):
+        return []
+    with open(filename, 'r') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        return [row for row in reader]
 
 def make_directory_tree(directory):
     if not os.path.exists(directory):

--- a/example/config.json
+++ b/example/config.json
@@ -47,9 +47,11 @@
         {
             "dataType": "func",
             "suffix": "bold",
-            "customLabels": "task-rest",
             "criteria": {
                 "equal": {"SeriesDescription": "rs_fMRI"}
+            }
+            "customHeader": {
+                "TaskName": "rest"
             }
         }
     ]

--- a/scripts/dcm2bids
+++ b/scripts/dcm2bids
@@ -55,12 +55,19 @@ def get_arguments():
             help="Select subset of series numbers (integers) for conversion",
             )
 
-
     parser.add_argument(
             "-o", "--outputdir",
             required=False,
             default=None,
             help="Output BIDS study directory (default current directory)",
+            )
+
+    parser.add_argument(
+            "-l", "--loglevel",
+            required=False,
+            default="INFO",
+            choices=["DEBUG","INFO","WARNING","ERROR","CRITICAL"],
+            help="Set logging level (the log file is written to outputdir)",
             )
 
     args = parser.parse_args()

--- a/scripts/dcm2bids
+++ b/scripts/dcm2bids
@@ -19,31 +19,31 @@ def get_arguments():
             "-d", "--dicom_dir",
             required=True,
             nargs="+",
-            help="DICOM files directory",
+            help="DICOM files directory(ies). Wild cards are supported.",
             )
 
     parser.add_argument(
             "-p", "--participant",
             required=True,
-            help="Name of the participant",
-            )
-
-    parser.add_argument(
-            "-s", "--session",
-            required=False, default=None,
-            help="Name of the session",
+            help="Participant number in BIDS output",
             )
 
     parser.add_argument(
             "-c", "--config",
             required=True, default=None,
-            help="json configuration file",
+            help="JSON configuration file (see example/config.json)",
+            )
+
+    parser.add_argument(
+            "-s", "--session",
+            required=False, default=None,
+            help="Session name/number",
             )
 
     parser.add_argument(
             "--clobber",
             required=False, action='store_true',
-            help="Overwrite output if exists",
+            help="Overwrite output if it exists",
             )
 
     parser.add_argument(
@@ -52,7 +52,7 @@ def get_arguments():
             required=False,
             nargs="+",
             default=None,
-            help="select subset of series numbers for conversion",
+            help="Select subset of series numbers (integers) for conversion",
             )
 
 
@@ -60,7 +60,7 @@ def get_arguments():
             "-o", "--outputdir",
             required=False,
             default=None,
-            help="output BIDS study directory",
+            help="Output BIDS study directory (default current directory)",
             )
 
     args = parser.parse_args()

--- a/scripts/dcm2bids
+++ b/scripts/dcm2bids
@@ -56,6 +56,13 @@ def get_arguments():
             )
 
 
+    parser.add_argument(
+            "-o", "--outputdir",
+            required=False,
+            default=None,
+            help="output BIDS study directory",
+            )
+
     args = parser.parse_args()
     return args
 

--- a/scripts/dcm2bids
+++ b/scripts/dcm2bids
@@ -46,6 +46,16 @@ def get_arguments():
             help="Overwrite output if exists",
             )
 
+    parser.add_argument(
+            "-n", "--selectseries",
+            type=int,
+            required=False,
+            nargs="+",
+            default=None,
+            help="select subset of series numbers for conversion",
+            )
+
+
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
outputdir is the root of the study, and everything gets written inside this directory.

outputdir has 3 folders: 1) sourcedata (bids converted data), 2) derivatives (empty - placed here to nudge users in the right, BIDS-compliant direction), 3) tmp_dcm2bids (so no longer kept in cwd).

We also keep a basic log in outputdir/dcm2bids.log, which is handy for keeping track of which dicom dirs went with which subject number etc... 

Depends on previous PRs.