### PR TITLE
Fix skeleton to validate “particpant_id” column

### DIFF
--- a/scripts/dcm2bids_scaffold
+++ b/scripts/dcm2bids_scaffold
@@ -71,7 +71,7 @@ TEXT_FILES = {
         " - Initialised study directory"
         ],
     "participants.tsv": [
-        "participants_id\teducation\tbmi",
+        "participant_id\teducation\tbmi",
         "sub-01\tn/a\tn/a",
         ],
     }


### PR DESCRIPTION
Hi @cbedetti,

Thanks for your work; this dcm2bids has been working very well for me. One very **tiny** fix, is that the skeleton currently creates a `participants.tsv` file which is invalid; the spec should have a column of `participant_id` instead of `participants_id` (no `s`) as it currently is created. It's a minuscule fix, but hopefully it should help other people when they're fighting with and [running and re-running](https://xkcd.com/1205/) the validator. 

Best, and keep up the good work,