### PR TITLE
Addresses #34 not ordering runs chronologically

### DIFF
--- a/dcm2bids/dcm2niix.py
+++ b/dcm2bids/dcm2niix.py
@@ -4,7 +4,7 @@
 import glob
 import logging
 import os
-from .utils import clean, run_shell_command
+from .utils import alphanum_sort, clean, run_shell_command
 
 
 class Dcm2niix(object):
@@ -54,7 +54,7 @@ class Dcm2niix(object):
             self.execute()
 
         self.sidecars = glob.glob(os.path.join(self.outputDir, "*.json"))
-        self.sidecars.sort()
+        self.sidecars = alphanum_sort(self.sidecars)
 
         return 0
 

--- a/dcm2bids/utils.py
+++ b/dcm2bids/utils.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import re
 import shutil
 import csv
 
@@ -58,6 +59,13 @@ def splitext_(path):
         if path.endswith(ext):
             return path[:-len(ext)], path[-len(ext):]
     return os.path.splitext(path)
+
+
+def alphanum_sort(_list):
+    convert = lambda text: int(text) if text.isdigit() else text
+    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+    sorted_list = sorted(_list, key=alphanum_key)
+    return sorted_list
 
 
 def dcm2niix_version():


### PR DESCRIPTION
this sorts series alphanumerically, which will sort like modalities in the proper order.
This fix will order all trailing-00-pad series last, but they will be in the proper order within 00-padded runs.
This only truly closes the issue if the trailing-00-pad of the Series Number is always respected within modalities.