### PR TITLE
updating anonymiser process - new version of pydeface

### DIFF
--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -96,8 +96,8 @@ class Dcm2bids(object):
                         and ".nii" in ext):
                     # it's an anat scan - try the anonymizer
                     self.logger.info("")
-                    cmd = "{0} {1} {2}".format(
-                            self.anonymizer, f, targetBase+ext)
+                    cmd = "{0} {1} {2} {3}".format(
+                            self.anonymizer, '--outfile', targetBase+ext, f)
                     run_shell_command(cmd)
                 else:
                     # just move


### PR DESCRIPTION
Fix for new version of pydeface, where "--outfile" flag is needed if one needs to indicate the outfile. Related to #38.

Potentially the existing solution is more flexible and users would simply need to wrap their anonymiser in a shell script that has the required outputs/inputs. In this case it would be good to improve documentation.