### PR TITLE
Do not use non-standard exit codes

### DIFF
--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -121,8 +121,6 @@ class Dcm2bids(object):
         check_latest()
         check_latest("dcm2niix")
 
-        return os.EX_OK
-
 
     def move(self, acquisition):
         """

--- a/dcm2bids/dcm2niix.py
+++ b/dcm2bids/dcm2niix.py
@@ -92,8 +92,6 @@ class Dcm2niix(object):
 
         self.sidecarFiles = glob(os.path.join(self.outputDir, "*.json"))
 
-        return os.EX_OK
-
 
     def execute(self):
         """ Execute dcm2niix for each directory in dicomDirs

--- a/scripts/dcm2bids_scaffold
+++ b/scripts/dcm2bids_scaffold
@@ -97,8 +97,6 @@ def main():
         if not os.path.exists(filepath):
             write_txt(filepath, data)
 
-    return os.EX_OK
-
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
Remove the use of the os.EX_OK exit codes because they are present only on Unix variants, and by just returning from these methods without setting an explicit exit code, the process will return with a successful exit code.

This should resolve https://github.com/cbedetti/Dcm2Bids/issues/59