### PR TITLE
Use Debugger to give a hint about a Config Field that doesn't match a given acquisition.

### DIFF
--- a/dcm2bids/sidecar.py
+++ b/dcm2bids/sidecar.py
@@ -384,9 +384,11 @@ class SidecarPairing(object):
             if isinstance(pattern, dict):
                 if len(pattern.keys()) == 1:
                     if "any" in pattern.keys():
-                        result.append(compare_complex(name, pattern))
+                        is_match = compare_complex(name, pattern)
+                        result.append(is_match)
                     elif list(pattern.keys())[0] in compare_float_keys:
-                        result.append(compare_float(name, pattern))
+                        is_match = compare_float(name, pattern)
+                        result.append(is_match)
                     else:
                         self.logger.warning(f"This key {list(pattern.keys())[0]} "
                                             "is not allowed.")
@@ -395,9 +397,13 @@ class SidecarPairing(object):
                                      "using only one key.")
 
             elif isinstance(name, list):
-                result.append(compare_list(name, pattern))
+                is_match = compare_list(name, pattern)
+                result.append(is_match)
             else:
-                result.append(compare(name, pattern))
+                is_match = compare(name, pattern)
+                result.append(is_match)
+            if not is_match:
+                self.logger.debug(f"Criteria not met for {tag}: {name} != {pattern}")
 
         return all(result)
 

--- a/dcm2bids/sidecar.py
+++ b/dcm2bids/sidecar.py
@@ -358,7 +358,7 @@ class SidecarPairing(object):
                     if len(sub_pattern) != 1:
                         raise ValueError(f"List for key {comparison} "
                                          "should have only one value. "
-                                         "Error val: {sub_pattern}")
+                                         f"Error val: {sub_pattern}")
 
                     sub_pattern = float(sub_pattern[0])
                 else:


### PR DESCRIPTION
I believe this is a _very_ slight improvement, in that if the user knows to switch on debug logging then they might actually get some insight into why JSON sidecars are not getting matched to any acquisitions.

But I think this should probably open up a larger discussion about how we can give a better hint to the user when the dreaded `"NO PARINGS FOUND"` warning shows up!

Personally It was not even clear to me what "No Pairing" means.

-----------------------------------------------------------------------------

xref https://github.com/UNFmontreal/Dcm2Bids/discussions/330

Here is what my output look like now:


```
INFO    | --- dcm2bids start ---
INFO    | Running the following command: /venv/bin/dcm2bids -o /bids -d /dicoms -p 1005 -c /config.json --auto_extract_entities -l DEBUG
INFO    | OS version: Linux-6.10.14-linuxkit-x86_64-with-glibc2.36
INFO    | Python version: 3.12.3 | packaged by conda-forge | (main, Apr 15 2024, 18:38:13) [GCC 12.3.0]
INFO    | dcm2bids version: 3.2.0
INFO    | dcm2niix version: v1.0.20240202
INFO    | Checking for software update
INFO    | Currently using the latest version of dcm2bids.
WARNING | A newer version exists for dcm2niix: v1.0.20241211
WARNING | You should update it -> https://github.com/rordenlab/dcm2niix.
INFO    | participant: sub-1005
INFO    | config: /config.json
INFO    | BIDS directory: /bids
INFO    | Auto extract entities: True
INFO    | Reorder entities: True
INFO    | Validate BIDS: False

WARNING | Previous dcm2bids temporary directory output found:
WARNING | /bids/tmp_dcm2bids/sub-1005
WARNING | Use --force_dcm2bids to rerun dcm2bids

DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092908 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091883 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092396 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.093929 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092908 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092908 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.09111 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.092139 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.086159 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.089947 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.086159 != 0.1
DEBUG   | Criteria not met for EchoTime: 0.091368 != 0.1
INFO    | SIDECAR PAIRING
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_06_20170924172843
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20181102193503
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180824193814
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20171111194644
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20171129195209
INFO    | No Pairing  <-  004_dicoms_Gotlib_BABIES_newborn_08_20181013191805
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_L-6month_0_20190220200045
INFO    | No Pairing  <-  004_dicoms_Gotlib_BABIES_newborn_08_20180601192426
INFO    | No Pairing  <-  005_dicoms_Gotlib_C_BABIES_newborn_20190516193314
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180826202801
INFO    | No Pairing  <-  005_dicoms_Gotlib_BABIES_newborn_01_20190311202517
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_01_20190215203139
INFO    | No Pairing  <-  012_dicoms_Gotlib_BABIES_newborn_06_20170725195912
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180124203642
INFO    | No Pairing  <-  006_dicoms_Gotlib_BABIES_newborn_08_20180518195137
INFO    | No Pairing  <-  003_dicoms_Gotlib_C_BABIES_newborn_20190726204858
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_01_20190117205109
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180403205753
INFO    | No Pairing  <-  012_dicoms_Gotlib_BABIES_newborn_06_20170705203834
INFO    | No Pairing  <-  007_dicoms_Gotlib_BABIES_newborn_08_20180716211053
INFO    | No Pairing  <-  004_dicoms_Gotlib_BABIES_newborn_08_20180806212428
INFO    | No Pairing  <-  004_dicoms_Gotlib_BABIES_newborn_05_20170602210230
INFO    | No Pairing  <-  003_dicoms_Gotlib_C_BABIES_newborn_20190423213712
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_01_20190223214101
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180129215534
INFO    | No Pairing  <-  008_dicoms_Gotlib_BABIES_newborn_08_20180905201421
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180119220701
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_06_20171024221336
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20171203221843
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180319222622
INFO    | No Pairing  <-  003_dicoms_Gotlib_C_BABIES_newborn_20190610223213
INFO    | No Pairing  <-  007_dicoms_Gotlib_BABIES_L-6month_0_20181212203020
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_01_20190316204528
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_06_20171002223456
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20171118223959
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180204225724
INFO    | No Pairing  <-  003_dicoms_Gotlib_BABIES_newborn_08_20180912232904
WARNING | NO PAIRING WAS FOUND. BIDS FOLDER "/BIDS/SUB-1005" WON'T BE CREATED. CHECK YOUR CONFIG FILE.

INFO    | Logs saved in /bids/tmp_dcm2bids/log/sub-1005_20250311-224329.log
INFO    | --- dcm2bids end ---
```